### PR TITLE
Add stored-energy map support

### DIFF
--- a/initMCPotts.m
+++ b/initMCPotts.m
@@ -1,4 +1,4 @@
-function [s, MCS, n, q, pacc, prex, time, N, nconfig, strain_energy, temperature, E0, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en] = initMCPotts(n, nstep, q, strain_energy, temperature, E0)
+function [s, MCS, n, q, pacc, prex, time, N, nconfig, strain_energy, temperature, E0, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en] = initMCPotts(n, nstep, q, strain_energy, temperature, E0)
     % Initialize the Monte Carlo Potts model
 
     % initialize variables
@@ -18,6 +18,15 @@ function [s, MCS, n, q, pacc, prex, time, N, nconfig, strain_energy, temperature
     grain_boundary_en = 0;
     strain_en = 0;
 
+    % create stored energy map from the provided value or matrix
+    if isscalar(strain_energy)
+        EsMap = strain_energy * ones(n);
+    else
+        EsMap = strain_energy;
+    end
+    % zero out recrystallized cells
+    EsMap(s == 1) = 0;
+
     % calculate initial grain boundary energy and strain energy
     for i = 1:n
 
@@ -25,7 +34,7 @@ function [s, MCS, n, q, pacc, prex, time, N, nconfig, strain_energy, temperature
             sij = s(i, j);
             sig = calculateEnergy(sij, s, n, i, j);
             grain_boundary_en = grain_boundary_en + E0 * (8 - sig) / 2;
-            strain_en = strain_en + strainEnergyAssign(s, i, j, 1, strain_energy);
+            strain_en = strain_en + strainEnergyAssign(s, i, j, 1, EsMap);
         end
 
     end

--- a/loadMCPotts.m
+++ b/loadMCPotts.m
@@ -1,10 +1,10 @@
-function [s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en] = loadMCPotts(MCS, new_strain_energy, new_temperature, new_E0)
+function [s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en] = loadMCPotts(MCS, new_strain_energy, new_temperature, new_E0)
     % Load the saved variables from a previous run
 
     file_name = ['restart_', num2str(MCS)];
     filepath = fullfile('output', file_name);
 
-    load(filepath, 's', 'MCS', 'n', 'q', 'pacc', 'prex', 'time', 'strain_energy', 'temperature', 'E0', 'totalEnergyArr', 'grainBoundaryEnergyArr', 'strainEnergyArr', 'total_en', 'grain_boundary_en', 'strain_en');
+    load(filepath, 's', 'MCS', 'n', 'q', 'pacc', 'prex', 'time', 'strain_energy', 'temperature', 'E0', 'EsMap', 'totalEnergyArr', 'grainBoundaryEnergyArr', 'strainEnergyArr', 'total_en', 'grain_boundary_en', 'strain_en');
 
     % Check if the new temperature is different from the previous one
     if new_temperature ~= temperature
@@ -16,20 +16,15 @@ function [s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, totalE
         E0 = new_E0;
     end
 
-    % Check if the new strain energy is different from the previous one
-    if new_strain_energy ~= strain_energy
-        strain_en = 0;
+    % Recalculate the strain energy using the stored energy map
+    strain_en = 0;
 
-        % Recalculate the strain energy for each lattice site
-        for i = 1:n
+    for i = 1:n
 
-            for j = 1:n
-                strain_en = strain_en + strainEnergyAssign(s, i, j, 1, new_strain_energy);
-            end
-
+        for j = 1:n
+            strain_en = strain_en + strainEnergyAssign(s, i, j, 1, EsMap);
         end
 
-        strain_energy = new_strain_energy;
     end
 
 end

--- a/runMCPotts.m
+++ b/runMCPotts.m
@@ -1,4 +1,4 @@
-function [totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, s, time] = runMCPotts(s, MCS, n, q, pacc, prex, time, N, nconfig, temperature, E0, strain_energy, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en)
+function [totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, s, time] = runMCPotts(s, MCS, n, q, pacc, prex, time, N, nconfig, temperature, E0, strain_energy, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en)
 % Perform Monte Carlo steps
 
 fig1 = figure(1);
@@ -62,8 +62,8 @@ for k = 1:nconfig
 
     sign = calculateEnergy(sij, s, n, i, j);
     sigo = calculateEnergy(sijo, s, n, i, j);
-    esn = double(sij ~= 1) * strain_energy;
-    eso = double(sijo ~= 1) * strain_energy;
+    esn = double(sij ~= 1) * EsMap(i, j);
+    eso = double(sijo ~= 1) * EsMap(i, j);
 
     del =- (sign - sigo) * E0;
     del_es = esn - eso;
@@ -140,7 +140,7 @@ for k = 1:nconfig
                 disp(['Snapshot saved at MCS = ', num2str(MCS), '!']);
         end
         if mod(MCS, 100) == 0
-                saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en);
+                saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en);
             if strain_energy
                 plotMCPotts(fig1, fig2, fig3, fig4, MCS, true, true, true, true);
             else
@@ -150,7 +150,7 @@ for k = 1:nconfig
         end
         % Save the current state every 100 MCS
         if mod(MCS, 100) == 0
-            saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en);
+            saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en);
 
             if strain_energy
                 plotMCPotts(fig1, fig2, fig3, fig4, MCS, true, true, true, true);

--- a/saveMCPotts.m
+++ b/saveMCPotts.m
@@ -1,4 +1,4 @@
-function saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en)
+function saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature, E0, EsMap, totalEnergyArr, grainBoundaryEnergyArr, strainEnergyArr, total_en, grain_boundary_en, strain_en)
     % Save variables to a file named 'restart-(MCS).mat'
 
     if ~exist('output', 'dir')
@@ -10,5 +10,5 @@ function saveMCPotts(s, MCS, n, q, pacc, prex, time, strain_energy, temperature,
     filepath = fullfile('output', file_name);
 
     % Save variables to the file
-    save(filepath, 's', 'MCS', 'n', 'q', 'pacc', 'prex', 'time', 'strain_energy', 'temperature', 'E0', 'totalEnergyArr', 'grainBoundaryEnergyArr', 'strainEnergyArr', 'total_en', 'grain_boundary_en', 'strain_en');
+    save(filepath, 's', 'MCS', 'n', 'q', 'pacc', 'prex', 'time', 'strain_energy', 'temperature', 'E0', 'EsMap', 'totalEnergyArr', 'grainBoundaryEnergyArr', 'strainEnergyArr', 'total_en', 'grain_boundary_en', 'strain_en');
 end

--- a/strainEnergyAssign.m
+++ b/strainEnergyAssign.m
@@ -1,8 +1,8 @@
-function [strainEnergy] = strainEnergyAssign(s, i, j, grainID, strain_energy)
-    % Assign strain energy based on the spin value
+function strainEnergy = strainEnergyAssign(s, i, j, grainID, EsMap)
+    % Assign strain energy based on the spin value and stored energy map
 
     if s(i, j) ~= grainID
-        strainEnergy = strain_energy;
+        strainEnergy = EsMap(i, j);
     else
         strainEnergy = 0;
     end

--- a/testMCPotts.m
+++ b/testMCPotts.m
@@ -1,4 +1,4 @@
-function energyChange = testMCPotts(n, s, E0, total_energy, strain_energy)
+function energyChange = testMCPotts(n, s, E0, total_energy, EsMap)
     % Calculate the percentage error in the final energy to ensure accurate updates
 
     % Initialize energy test variables
@@ -20,7 +20,7 @@ function energyChange = testMCPotts(n, s, E0, total_energy, strain_energy)
 
             % Check for strain energy
             if sij ~= 1
-                strain_energy_test = strain_energy_test + strain_energy;
+                strain_energy_test = strain_energy_test + EsMap(i, j);
             end
 
         end


### PR DESCRIPTION
## Summary
- extend Monte Carlo functions to handle per-site stored energy maps
- use `EsMap` to compute strain energy throughout
- save and reload `EsMap` with restart files
- update energy test and default input parsing for matrices

## Testing
- `octave` not found, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6846e98de7108320845685def12d1daa